### PR TITLE
docker-compose: Corrected mount path of the config volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - "9000:9000"
     restart: always
     volumes:
-      - ~/.thelounge:/home/lounge/data # bind lounge config from the host's file system
+      - ~/.thelounge:/var/opt/thelounge # bind lounge config from the host's file system


### PR DESCRIPTION
Adjusted the mount path of the volume in the docker-compose.yml to macht the path in the README.md