### PR TITLE
Update Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ docker run --detach \
 		--publish 5000:9000 \ # Change host port to listen on port 5000
 		--volume ~/.thelounge:/home/lounge/data \
 		--restart always \
-		thelounge/lounge:latest
+		thelounge/thelounge:latest
 ```
 
 ## Environment variables (advanced usage)


### PR DESCRIPTION
It looks like https://hub.docker.com/r/thelounge/lounge/ image is no longer maintained. This commit updates the `README.md` to point to the new image.