### PR TITLE
Fix bug in conditional expression

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$1" = "thelounge" -a "$(id -u)" = '0' ]; then
+if [ "$1" = "thelounge" ] && [ "$(id -u)" = '0' ]; then
     find "${THELOUNGE_HOME}" \! -user node -exec chown node '{}' +
     exec su node -c "$*"
 fi


### PR DESCRIPTION
Shellcheck complains that use of '-a' is not well-defined and recommends '&&', and also to separate each expression between '&&' with brackets. Before this change, the resulting container was stuck in a restart loop.