### PR TITLE
Build for ARM (ARM64 + ARMv7)

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -20,7 +20,9 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
+          echo $DOCKER_USERNAME
 
       - name: Setup buildx
         run: |

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -16,10 +16,11 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Docker login
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: echo $DOCKER_USERNAME
+        run: echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
 
       - name: Setup buildx
         run: |

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Docker login
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -19,9 +19,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
-          && echo $DOCKER_USERNAME
+        run: echo $DOCKER_USERNAME
 
       - name: Setup buildx
         run: |

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -1,9 +1,6 @@
-name: Push Docker image
+name: Build (and push) multi-arch Docker image
 
-on:
-  push:
-    tags:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   build:
@@ -19,6 +16,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Docker login
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -35,21 +33,25 @@ jobs:
           PLATFORMS: linux/amd64,linux/arm64/v8,linux/arm/v7
           DOCKER_REPOSITORY: thelounge/thelounge
         run: |
-          VERSION="$(git describe --exact-match --tags)"
-          TAG="${VERSION}"
-          LATEST_TAG="latest"
-          if grep -q "^alpine/" <<< "${{ matrix.dockerfile }}"; then
-            TAG="${TAG}-alpine"
-            LATEST_TAG="alpine"
-          fi
+          TAG="$(git rev-parse --short HEAD)"
           EXTRA_ARG=()
-          # If not a pre-release push LATEST_TAG
-          if grep -qE "^[0-9]*\.[0-9]*\.[0-9]*$" <<< "${VERSION}"; then
-            EXTRA_ARG+=("--tag" "${DOCKER_REPOSITORY}:${LATEST_TAG}")
+          # Only push on regular push (!= pull_request)
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && grep -q "^refs/tags/" <<< "${GITHUB_REF}"; then
+            EXTRA_ARG+=("--push")
+            VERSION="$(git describe --exact-match --tags)"
+            TAG="${VERSION}"
+            LATEST_TAG="latest"
+            if grep -q "^alpine/" <<< "${{ matrix.dockerfile }}"; then
+              TAG="${TAG}-alpine"
+              LATEST_TAG="alpine"
+            fi
+            # If not a pre-release push LATEST_TAG
+            if grep -qE "^[0-9]*\.[0-9]*\.[0-9]*$" <<< "${VERSION}"; then
+              EXTRA_ARG+=("--tag" "${DOCKER_REPOSITORY}:${LATEST_TAG}")
+            fi
           fi
           docker buildx build \
             --platform "${PLATFORMS}" \
-            --push \
             --tag "${DOCKER_REPOSITORY}:${TAG}" \
             "${EXTRA_ARG[@]}" \
             --file "${{ matrix.dockerfile }}" \

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -21,7 +21,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
-          echo $DOCKER_USERNAME
+          && echo $DOCKER_USERNAME
 
       - name: Setup buildx
         run: |

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build Docker image
         env:
-          PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+          PLATFORMS: linux/amd64,linux/arm64/v8,linux/arm/v7
           DOCKER_REPOSITORY: thelounge/thelounge
         run: |
           VERSION="$(git describe --exact-match --tags)"

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -1,0 +1,56 @@
+name: Push Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build
+    # We want a newer version of qemu: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1815100
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [Dockerfile, alpine/Dockerfile]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Docker login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin docker.io
+
+      - name: Setup buildx
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+          docker buildx create --use
+
+      - name: Build Docker image
+        env:
+          PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+          DOCKER_REPOSITORY: thelounge/thelounge
+        run: |
+          VERSION="$(git describe --exact-match --tags)"
+          TAG="${VERSION}"
+          LATEST_TAG="latest"
+          if grep -q "^alpine/" <<< "${{ matrix.dockerfile }}"; then
+            TAG="${TAG}-alpine"
+            LATEST_TAG="alpine"
+          fi
+          EXTRA_ARG=()
+          # If not a pre-release push LATEST_TAG
+          if grep -qE "^[0-9]*\.[0-9]*\.[0-9]*$" <<< "${VERSION}"; then
+            EXTRA_ARG+=("--tag" "${DOCKER_REPOSITORY}:${LATEST_TAG}")
+          fi
+          docker buildx build \
+            --platform "${PLATFORMS}" \
+            --push \
+            --tag "${DOCKER_REPOSITORY}:${TAG}" \
+            "${EXTRA_ARG[@]}" \
+            --file "${{ matrix.dockerfile }}" \
+            .

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,5 +16,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install thelounge.
 ARG THELOUNGE_VERSION=4.2.0-pre.2
-RUN yarn --non-interactive --frozen-lockfile global add thelounge@${THELOUNGE_VERSION} && \
-    yarn --non-interactive cache clean
+RUN apk --update --no-cache add python build-base && \
+    yarn --non-interactive --frozen-lockfile global add thelounge@${THELOUNGE_VERSION} && \
+    yarn --non-interactive cache clean && \
+    apk del python build-base


### PR DESCRIPTION
With this commit we switch from "Automated Builds"[1] to using a GitHub
Actions for building the Docker images. This makes it possible to use
buildx[2] and build the images for other platforms besides amd64.

The workflow is only triggered when a tag is pushed and the latest tag
(`latest` or `alpine`) is only pushed when the tag match the following
regex: "^[0-9]*\.[0-9]*\.[0-9]*$".

[1] https://docs.docker.com/docker-hub/builds/
[2] https://github.com/docker/buildx

Fix #99

---
@xPaw [automated builds](https://docs.docker.com/docker-hub/builds/) needs to be disabled, and you need to create the secret `DOCKER_USERNAME` and `DOCKER_PASSWORD` (you should use a [access token](https://docs.docker.com/docker-hub/access-tokens/)).