### PR TITLE
Update base image to node:lts-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-bullseye
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Debian 11 "bullseye" has been released as stable, with stretch transitioning to oldoldstable

I noticed in thelounge/thelounge#4257 that an old version of ImageMagick in stretch was an issue for supporting HEIF, and thought that this update now seems reasonable.

I made a test build, which seems to work okay. Hopefully others can help to sanity check / test too :slightly_smiling_face: 