### PR TITLE
thelounge@4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 4.3.1-rc.1 (2022-03-03)
+## 4.3.1 (2022-04-12)
 - Rebuild latest stable release images on a weekly basis.
-- Bump [`thelounge`][1] to [`4.3.1-rc.1`](https://github.com/thelounge/thelounge/releases/tag/v4.3.1-rc.1).
+- Bump [`thelounge`][1] to [`4.3.1`](https://github.com/thelounge/thelounge/releases/tag/v4.3.1).
 
 #### Breaking changes
 - Only provide an alpine image. The `:alpine` tag will now be `:latest`. Versioned tags will also no longer have the `-alpine` suffix.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ CMD ["thelounge", "start"]
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install thelounge.
-ARG THELOUNGE_VERSION=4.3.1-rc.1
+ARG THELOUNGE_VERSION=4.3.1
 RUN apk --update --no-cache --virtual build-deps add python2 build-base git && \
     yarn --non-interactive --frozen-lockfile global add thelounge@${THELOUNGE_VERSION} && \
     yarn --non-interactive cache clean && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-THELOUNGE_VERSION?=4.3.1-rc.1
+THELOUNGE_VERSION?=4.3.1
 ORGANISATION?=thelounge
 
 all: main


### PR DESCRIPTION
Updates thelounge to 4.3.1.

I edited the CHANGELOG as with the releases before, removing -beta or -rc releases in favour of stable releases.