### PR TITLE
fix(release-please): use custom token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,8 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
+          token: ${{ secrets.PAT }}
           release-type: simple
           package-name: thelounge-docker
           prerelease: true
           include-v-in-tag: false
-          labels: |
-            automerge


### PR DESCRIPTION
This fixes issues where the default bot account associated with the
default `secrets.GITHUB_TOKEN` is unable to trigger other workflows.
