### PR TITLE
chore: pin Node to v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:18-alpine
 
 ARG THELOUNGE_VERSION=4.4.1
 


### PR DESCRIPTION
QEMU is unable to build the image on linux/arm/v7 on the latest LTS
(v20). Seemingly related to https://gitlab.com/qemu-project/qemu/-/issues/1729.
