### PR TITLE
remove compose file version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   thelounge:
     image: ghcr.io/thelounge/thelounge:latest


### PR DESCRIPTION
`version` is no longer used in docker compose CLI, and recent Docker Desktop versions warn about its inclusion.

> Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It is implemented in versions 1.27.0 and above (also known as Compose V2) of the Docker Compose CLI.

https://docs.docker.com/compose/compose-file/